### PR TITLE
Sélection rapide d'apprenant

### DIFF
--- a/classes/output/renderable/training_management.php
+++ b/classes/output/renderable/training_management.php
@@ -346,8 +346,10 @@ class training_management implements \renderable {
                     $output .= "<br /> ";
                     $output .= $this->form2->render();
 
+                    $countlearner = $training->count_learners();
+                    $textlearner = get_string('learners', 'tool_attestoodle') . " (". $countlearner. ")";
                     $output .= "<br/><legend class='ftogger'><a class='fheader' href='#'>" .
-                        get_string('learners', 'tool_attestoodle') . "</a></legend>";
+                        $textlearner . "</a></legend>";
 
                     $parameters = array(
                         'categoryid' => $this->categoryid,
@@ -364,7 +366,7 @@ class training_management implements \renderable {
                         'categoryid' => $this->categoryid,
                         'trainingid' => $this->trainingid
                     );
-                    if ($training->has_learners()) {
+                    if ($countlearner > 0) {
                         $url = new \moodle_url('/admin/tool/attestoodle/index.php', $parameters);
                         $label = get_string('training_management_training_details_link', 'tool_attestoodle');
                         $attributes = array('class' => 'btn btn-default attestoodle-button');

--- a/classes/training.php
+++ b/classes/training.php
@@ -90,6 +90,13 @@ class training {
     }
 
     /**
+     * Return the count of learners.
+     */
+    public function count_learners() {
+        return db_accessor::get_instance()->get_count_learner($this->id);
+    }
+
+    /**
      * Getter for the $start property.
      *
      * @return integer date start of the training.

--- a/lang/en/tool_attestoodle.php
+++ b/lang/en/tool_attestoodle.php
@@ -309,3 +309,6 @@ $string['learners'] = 'Learners';
 $string['fortraining'] = ' for training : {$a}';
 $string['confirmtraincreate'] = 'Do you want to create a new formation ?';
 $string['errsendzip'] = 'An error occured: impossible to send ZIP file.';
+$string['validate'] = 'Validate';
+$string['trainingcriteria'] = 'Training criteria';
+$string['enrolcriteria'] = 'Enrol criteria';

--- a/lang/fr/tool_attestoodle.php
+++ b/lang/fr/tool_attestoodle.php
@@ -300,3 +300,6 @@ $string['learners'] = 'Apprenants';
 $string['fortraining'] = ' pour la formation : {$a}';
 $string['confirmtraincreate'] = 'Voulez-vous créer une nouvelle formation ?';
 $string['errsendzip'] = 'Erreur : téléchargement du fichier zip impossible !!';
+$string['validate'] = 'Valider';
+$string['trainingcriteria'] = 'Critère formation';
+$string['enrolcriteria'] = 'Critère inscription';

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->release   = 'v1.5.2';             // The current plugin release
-$plugin->version   = 2019061901;         // The current plugin version (Date: YYYYMMDDXX).10
+$plugin->release   = 'v1.6.0';             // The current plugin release
+$plugin->version   = 2019062601;         // The current plugin version (Date: YYYYMMDDXX).10
 $plugin->requires  = 2012112900;         // Requires this Moodle version.
 $plugin->component = 'tool_attestoodle'; // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
Précaution d'emploi
**Attention** les anciennes listes d'apprenants doivent êtres **validées** pour être conformes.
Il faut donc choisir chaque ancienne formation, cliquer sur [sélectionner les apprenants] puis sur valider.