### PR TITLE
Bugfix 20191001

### DIFF
--- a/classes/output/renderable/training_milestones.php
+++ b/classes/output/renderable/training_milestones.php
@@ -55,6 +55,7 @@ class training_milestones implements \renderable {
     public function __construct($categoryid, $trainingid) {
         $this->categoryid = $categoryid;
         $this->training = trainings_factory::get_instance()->retrieve_training_by_id($trainingid);
+        $this->trainingid = required_param('trainingid', PARAM_INT);
 
         $type = optional_param('type', null, PARAM_ALPHANUMEXT);
         $namemod = optional_param('namemod', null, PARAM_TEXT);
@@ -72,7 +73,6 @@ class training_milestones implements \renderable {
                 if (has_capability('tool/attestoodle:managemilestones', $context)) {
                     $modifallow = true;
                 }
-                $this->trainingid = required_param('trainingid', PARAM_INT);
                 $url = new \moodle_url(
                             '/admin/tool/attestoodle/index.php',
                             ['typepage' => 'managemilestones',

--- a/classes/training/course_outof_categ.php
+++ b/classes/training/course_outof_categ.php
@@ -43,7 +43,7 @@ $type = optional_param('type', null, PARAM_ALPHANUMEXT);
 $namemod = optional_param('namemod', null, PARAM_ALPHANUMEXT);
 $visibmod = optional_param('visibmod', 0, PARAM_INT);
 $restrictmod = optional_param('restrictmod', 0, PARAM_INT);
-$coursename = optional_param('coursename', '', PARAM_ALPHA);
+$coursename = optional_param('coursename', '', PARAM_NOTAGS);
 
 $coursetoadd = search_course($coursename, $categoryid, $trainingid);
 $url = new \moodle_url('/admin/tool/attestoodle/classes/training/course_outof_categ.php',

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->release   = 'v1.7.6';             // The current plugin release
-$plugin->version   = 2019090404;         // The current plugin version (Date: YYYYMMDDXX).10
+$plugin->release   = 'v1.7.7';             // The current plugin release
+$plugin->version   = 2019100103;         // The current plugin version (Date: YYYYMMDDXX).10
 $plugin->requires  = 2012112900;         // Requires this Moodle version.
 $plugin->component = 'tool_attestoodle'; // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
Permet la création de formation dans une catégorie sans cours.
Il est aussi possible de saisir des underscores dans le noms abrégé des cours lors de l'ajout de jalons